### PR TITLE
Adds serializer for index action

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::ArticlesController < ApplicationController
 
   def index
     articles = Article.all
-    render json: { entries: articles }
+    render json: { data: articles }, each_serializer: Articles::IndexSerializer
   end
 
   def create

--- a/app/serializers/articles/index_serializer.rb
+++ b/app/serializers/articles/index_serializer.rb
@@ -1,0 +1,3 @@
+class Articles::IndexSerializer < ActiveModel::Serializer
+  attributes :id, :title, :ingress, :image
+end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Api::V1::ArticlesController, type: :request do
 
     it 'returns a collection of articles' do
       get '/api/v1/articles', headers: headers
-      expect(json_response['entries'].count).to eq 5
+      expect(json_response['data'].count).to eq 5
     end
 
     it 'returns 200 response' do


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/166243232)

## Changes we propose in this PR
* Adds serializer for index action
* Renames response body field from `entries` to `data`

## What we have learned
* How to make use of serializer