### PR TITLE
Expiry Token 2 weeks

### DIFF
--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -9,7 +9,7 @@ DeviseTokenAuth.setup do |config|
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  config.token_lifespan = 24.hours
+  #  config.token_lifespan = 2.weeks
 
   # Sets the max number of concurrent devices per user, which is 10 by default.
   # After this limit is reached, the oldest tokens will be removed.


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/166410858)

### Changes we propose
* Puts expiry of token back at 2 weeks cause otherwise we could not save credentials in localstorage