### PR TITLE
Article `published` status not updating to `true` - BUG FIX

### DIFF
--- a/app/controllers/api/v1/reviews_controller.rb
+++ b/app/controllers/api/v1/reviews_controller.rb
@@ -27,7 +27,7 @@ class Api::V1::ReviewsController < ApplicationController
     if article.reviews.count >= 3
       average_score = article.reviews.sum(&:score)/article.reviews.count.to_f
       if average_score >= 6
-        article.update(published: :true)
+        article.update_column(:published, [true])
       end
     end
   end


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/166497898)

### Changes proposed in this bug fix PR
* Modifies the update method of an article under creating reviews. Previously, the article status `published` was not updated if `average_score` was within permitted parameters